### PR TITLE
chore(cla): allowlist dependabot[bot] in CAA contributors

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -3,6 +3,7 @@
   "label": "cla-signed",
   "recheckComment": "recheck",
   "contributors": [
-    "oscarvalenzuelab"
+    "oscarvalenzuelab",
+    "dependabot[bot]"
   ]
 }


### PR DESCRIPTION
Allows dependabot to bypass the CAA-signed check on its automated PRs.

Observed during a multi-repo secops sweep where every dependabot PR failed `cla-signed` because the bot cannot post a CAA acceptance comment. This entry mirrors the pattern already in place on AgentJunior, AIWebCrawler, aiproxyguard-npm-sdk, aiproxyguard-python-sdk, prompt-injection-benchmark, and aisniff-server.